### PR TITLE
Fix/combined args ls command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1214,6 +1214,11 @@
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
       "dev": true
     },
+    "lodash.partition": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.partition/-/lodash.partition-4.6.0.tgz",
+      "integrity": "sha1-o45GtzRp4EILDaEhLmbUFL42S6Q="
+    },
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -33,10 +33,11 @@
   "license": "MIT",
   "dependencies": {
     "array.prototype.findindex": "^2.0.0",
+    "lodash.partition": "^4.6.0",
+    "sprintf-js": "^1.1.2",
     "string.prototype.includes": "^1.0.0",
     "string.prototype.repeat": "^0.2.0",
-    "string.prototype.startswith": "^0.2.0",
-    "sprintf-js": "^1.1.2"
+    "string.prototype.startswith": "^0.2.0"
   },
   "devDependencies": {
     "istanbul": "^0.4.3",

--- a/src/commands/ls.js
+++ b/src/commands/ls.js
@@ -28,7 +28,7 @@ function ls (env, commandOptions) {
   }
 
   function formatListing (basePath, listing) {
-    const listings = listing.map(filePath => env.system.stat(`${basePath}/${filePath}`))
+    const listingStats = listing.map(filePath => env.system.stat(`${basePath}/${filePath}`))
 
     const applyAddonsForStatsName = ({ type, name }) => {
       const lsColor = env.system.state.addons.ls_colors[type]
@@ -79,7 +79,7 @@ function ls (env, commandOptions) {
       return lines.join(' ')
     }
 
-    return Promise.all(listings)
+    return Promise.all(listingStats)
       .then(filesStats => filesStats
         .sort(sortFileStatsEntries)
         .map(formatFileStatsEntries)
@@ -87,7 +87,7 @@ function ls (env, commandOptions) {
   }
 
   const rejectHiddenListings = listing => showHiddenFiles ? listing : listing.filter(l => !l.startsWith('.'))
-  const listings = args
+  const formattedListings = args
     .sort()
     .map(path => env.system.readDir(path)
       .then(rejectHiddenListings)
@@ -95,7 +95,7 @@ function ls (env, commandOptions) {
       .then(listing => args.length === 1 ? listing : `${path}:\n${listing}`)
     )
 
-  Promise.all(listings)
+  Promise.all(formattedListings)
     .then(listings => listings.join('\n\n'))
     .then(result => {
       env.output(result)

--- a/src/commands/ls.js
+++ b/src/commands/ls.js
@@ -7,8 +7,10 @@ const LS_COMMAND_FLAGS = Object.freeze({
   ENTRY_PER_ROW: '1'
 })
 
+const FILE_TYPE_DIR = 'dir'
+
 function parseCommandFlagsAndArgs(commandArgs) {
-  let [commandFlags, args] = partition(commandArgs, arg => /-\w+/.test(arg))
+  const [commandFlags, args] = partition(commandArgs, arg => /-\w+/.test(arg))
   
   if (args.length === 0) { args.push('.') }
 
@@ -31,8 +33,8 @@ function ls (env, commandOptions) {
   const entryPerRow = flags.has(LS_COMMAND_FLAGS.ENTRY_PER_ROW)
 
   function sortEntries (a, b) {
-    var isFirstDir = a.type === 'dir'
-    var isSecondDir = b.type === 'dir'
+    var isFirstDir = a.type === FILE_TYPE_DIR
+    var isSecondDir = b.type === FILE_TYPE_DIR
     if (isFirstDir && !isSecondDir) return -1
     if (!isFirstDir && isSecondDir) return 1
     if (a.name < b.name) return -1
@@ -58,7 +60,7 @@ function ls (env, commandOptions) {
       return `${day} ${hour}`
     }
 
-    const getChmod = fileType => (fileType === 'dir') ? 'drwxrwxr-x' : '-rw-rw-r--'
+    const getChmod = fileType => (fileType === FILE_TYPE_DIR) ? 'drwxrwxr-x' : '-rw-rw-r--'
 
     return Promise.all(listing.map(getFileStats))
       .then(filesStats => {
@@ -74,7 +76,7 @@ function ls (env, commandOptions) {
           if (!longFormat) {
             return name
           }
-          if (type === 'dir') {
+          if (type === FILE_TYPE_DIR) {
             name = name + '/'
           }
           const date = new Date(stats.modified)

--- a/src/commands/ls.js
+++ b/src/commands/ls.js
@@ -2,7 +2,7 @@ const sprintf = require('sprintf-js').sprintf
 const parseCommandArgs = require('../utils/parseCommandArgs')
 
 const LS_COMMAND_FLAGS = Object.freeze({
-  SHOW_HIDDEN: 'a',
+  SHOW_HIDDEN_FILES: 'a',
   SHOW_ENTRY_PER_ROW: '1',
   USE_LONG_FORMAT: 'l'
 })
@@ -16,9 +16,16 @@ function ls (env, commandOptions) {
 
   if (args.length === 0) { args.push('.') }
 
-  const showHidden = flags.includes(LS_COMMAND_FLAGS.SHOW_HIDDEN)
-  const showEntryPerRow = flags.includes(LS_COMMAND_FLAGS.SHOW_ENTRY_PER_ROW)
-  const useLongFormat = flags.includes(LS_COMMAND_FLAGS.USE_LONG_FORMAT)
+  const showHiddenFiles = flags.includes(LS_COMMAND_FLAGS.SHOW_HIDDEN_FILES)
+  let showEntryPerRow = flags.includes(LS_COMMAND_FLAGS.SHOW_ENTRY_PER_ROW)
+  let useLongFormat = flags.includes(LS_COMMAND_FLAGS.USE_LONG_FORMAT)
+
+  // if both flags are enabled then choose the last one
+  if (showEntryPerRow && useLongFormat) {
+    useLongFormat = flags.lastIndexOf(LS_COMMAND_FLAGS.USE_LONG_FORMAT) >
+      flags.lastIndexOf(LS_COMMAND_FLAGS.SHOW_ENTRY_PER_ROW)
+    showEntryPerRow = !useLongFormat
+  }
 
   function formatListing (basePath, listing) {
     const listings = listing.map(filePath => env.system.stat(`${basePath}/${filePath}`))
@@ -79,7 +86,7 @@ function ls (env, commandOptions) {
       ).then(joinFileStatsEntriesLines)
   }
 
-  const rejectHiddenListings = listing => showHidden ? listing : listing.filter(l => !l.startsWith('.'))
+  const rejectHiddenListings = listing => showHiddenFiles ? listing : listing.filter(l => !l.startsWith('.'))
   const listings = args
     .sort()
     .map(path => env.system.readDir(path)

--- a/src/commands/ls.js
+++ b/src/commands/ls.js
@@ -1,114 +1,102 @@
 const sprintf = require('sprintf-js').sprintf
-const partition = require('lodash.partition')
+const parseCommandArgs = require('../utils/parseCommandArgs')
 
 const LS_COMMAND_FLAGS = Object.freeze({
   SHOW_HIDDEN: 'a',
-  LONG_FORMAT: 'l',
-  ENTRY_PER_ROW: '1'
+  SHOW_ENTRY_PER_ROW: '1',
+  USE_LONG_FORMAT: 'l'
 })
-
 const FILE_TYPE_DIR = 'dir'
-
-function parseCommandFlagsAndArgs(commandArgs) {
-  const [commandFlags, args] = partition(commandArgs, arg => /-\w+/.test(arg))
-  
-  if (args.length === 0) { args.push('.') }
-
-  const uniqueFlags = new Set(
-    commandFlags.map(arg => arg.substring(1))
-      .join('')
-      .split('')
-  )
-  return [uniqueFlags, args]
-}
 
 function ls (env, commandOptions) {
   // Ignore command name
   commandOptions.shift()
 
-  let [flags, args] = parseCommandFlagsAndArgs(commandOptions)
-  
-  const showHidden = flags.has(LS_COMMAND_FLAGS.SHOW_HIDDEN)
-  const longFormat = flags.has(LS_COMMAND_FLAGS.LONG_FORMAT)
-  const entryPerRow = flags.has(LS_COMMAND_FLAGS.ENTRY_PER_ROW)
+  const [flags, args] = parseCommandArgs(commandOptions)
 
-  function sortEntries (a, b) {
-    var isFirstDir = a.type === FILE_TYPE_DIR
-    var isSecondDir = b.type === FILE_TYPE_DIR
-    if (isFirstDir && !isSecondDir) return -1
-    if (!isFirstDir && isSecondDir) return 1
-    if (a.name < b.name) return -1
-    if (a.name > b.name) return 1
-    return 0
-  }
+  if (args.length === 0) { args.push('.') }
 
-  function formatListing (base, listing) {
-    const getFileStats = filePath => env.system.stat(`${base}/${filePath}`)
-    const formatLines = lines => {
-      if (longFormat) {
+  const showHidden = flags.includes(LS_COMMAND_FLAGS.SHOW_HIDDEN)
+  const showEntryPerRow = flags.includes(LS_COMMAND_FLAGS.SHOW_ENTRY_PER_ROW)
+  const useLongFormat = flags.includes(LS_COMMAND_FLAGS.USE_LONG_FORMAT)
+
+  function formatListing (basePath, listing) {
+    const listings = listing.map(filePath => env.system.stat(`${basePath}/${filePath}`))
+
+    const applyAddonsForStatsName = ({ type, name }) => {
+      const lsColor = env.system.state.addons.ls_colors[type]
+      return lsColor ? lsColor(name) : name
+    }
+
+    const statsLongFormat = stats => {
+      const buildStatsName = stats => {
+        const statsName = applyAddonsForStatsName(stats)
+        return stats.type === FILE_TYPE_DIR ? (statsName + '/') : statsName
+      }
+
+      const extractTimestamp = date => {
+        const dateString = date.toString()
+        const day = dateString.match(/(\w+\s\d+)/)[1]
+        const hour = dateString.match(/(\d+:\d+)/)[1]
+        return `${day} ${hour}`
+      }
+
+      const getChmod = fileType => (fileType === FILE_TYPE_DIR) ? 'drwxrwxr-x' : '-rw-rw-r--'
+
+      const chmod = getChmod(stats.type)
+      const formattedSize = sprintf('%5s', stats.size)
+      const date = new Date(stats.modified)
+      const timestamp = extractTimestamp(date)
+      const statsName = buildStatsName(stats)
+      return `${chmod} ${env.system.state.user} ${env.system.state.group} ${formattedSize} ${timestamp}  ${statsName}`
+    }
+
+    const sortFileStatsEntries = (a, b) => {
+      const isFirstDir = a.type === FILE_TYPE_DIR
+      const isSecondDir = b.type === FILE_TYPE_DIR
+      if (isFirstDir && !isSecondDir) return -1
+      if (!isFirstDir && isSecondDir) return 1
+      if (a.name < b.name) return -1
+      if (a.name > b.name) return 1
+      return 0
+    }
+
+    const formatFileStatsEntries = stats => useLongFormat ? statsLongFormat(stats) : applyAddonsForStatsName(stats)
+
+    const joinFileStatsEntriesLines = lines => {
+      if (useLongFormat) {
         return `total ${lines.length}\n${lines.join('\n')}`
-      } else if (entryPerRow) {
+      } else if (showEntryPerRow) {
         return lines.join('\n')
       }
       return lines.join(' ')
     }
 
-    const extractTimestamp = date => {
-      const dateString = date.toString()
-      const day = dateString.match(/(\w+\s\d+)/)[1]
-      const hour = dateString.match(/(\d+:\d+)/)[1]
-      return `${day} ${hour}`
-    }
-
-    const getChmod = fileType => (fileType === FILE_TYPE_DIR) ? 'drwxrwxr-x' : '-rw-rw-r--'
-
-    return Promise.all(listing.map(getFileStats))
-      .then(filesStats => {
-        filesStats.sort(sortEntries)
-        return filesStats.map(stats => {
-          const type = stats.type
-          const lsColor = env.system.state.addons.ls_colors[type]
-
-          let name = stats.name
-          if (lsColor) {
-            name = lsColor(name)
-          }
-          if (!longFormat) {
-            return name
-          }
-          if (type === FILE_TYPE_DIR) {
-            name = name + '/'
-          }
-          const date = new Date(stats.modified)
-          const timestamp = extractTimestamp(date)
-          const chmod = getChmod(type)
-          const size = sprintf('%5s', stats.size)
-          return `${chmod} ${env.system.state.user} ${env.system.state.group} ${size} ${timestamp}  ${name}`
-        })
-      }).then(formatLines)
+    return Promise.all(listings)
+      .then(filesStats => filesStats
+        .sort(sortFileStatsEntries)
+        .map(formatFileStatsEntries)
+      ).then(joinFileStatsEntriesLines)
   }
 
-  const excludeHidden = listing => showHidden ? listing : listing.filter(l => !l.startsWith('.'))
-
-  Promise.all(args.sort().map(path => {
-    return env.system.readDir(path)
-      .then(excludeHidden)
+  const rejectHiddenListings = listing => showHidden ? listing : listing.filter(l => !l.startsWith('.'))
+  const listings = args
+    .sort()
+    .map(path => env.system.readDir(path)
+      .then(rejectHiddenListings)
       .then(listing => formatListing(path, listing))
-      .then(formattedListing => {
-        if (args.length === 1) {
-          return formattedListing
-        }
-        return `${path}:\n${formattedListing}`
-      })
-  }))
-  .then(listings => listings.join('\n\n'))
-  .then(result => {
-    env.output(result)
-    env.exit()
-  }, err => {
-    env.output('ls: ' + err)
-    env.exit(2)
-  })
+      .then(listing => args.length === 1 ? listing : `${path}:\n${listing}`)
+    )
+
+  Promise.all(listings)
+    .then(listings => listings.join('\n\n'))
+    .then(result => {
+      env.output(result)
+      env.exit()
+    }, err => {
+      env.output('ls: ' + err)
+      env.exit(2)
+    })
 }
 
 module.exports = ls

--- a/src/utils/parseCommandArgs.js
+++ b/src/utils/parseCommandArgs.js
@@ -1,0 +1,12 @@
+const partition = require('lodash.partition')
+
+function parseCommandArgs (commandArgs) {
+  const [commandFlags, remainingArgs] = partition(commandArgs, arg => /-\w+/.test(arg))
+  const flagsInOrder = commandFlags.map(arg => arg.substring(1))
+    .join('')
+    .split('')
+
+  return [flagsInOrder, remainingArgs]
+}
+
+module.exports = parseCommandArgs

--- a/test/commands/ls.js
+++ b/test/commands/ls.js
@@ -2,7 +2,7 @@ var test = require('tape')
 var bashEmulator = require('../../src')
 
 test('ls', function (t) {
-  t.plan(11)
+  t.plan(14)
 
   var emulator = bashEmulator({
     history: [],
@@ -131,5 +131,25 @@ test('ls', function (t) {
       '-rw-rw-r-- test user   123 Jan 01 03:35  README'
     t.equal(output, listing, 'combine -a and -l')
   })
+
+  emulator.run('ls -a -1 /home/test').then(function (output) {
+    t.equal(output, 'dir\n.secret\nREADME', 'list all & entry per line')
+  })
+
+  emulator.run('ls -a1 /home/test').then(function (output) {
+    t.equal(output, 'dir\n.secret\nREADME', 'list all & entry per line combined flags')
+  })
+
+  emulator.run('ls -1a /home/test').then(function (output) {
+    t.equal(output, 'dir\n.secret\nREADME', 'list all & entry per line combined flags reverse order')
+  })
+
+  // emulator.run('ls -l -a -1 /home/test').then(function (output) {
+  //   t.equal(output, 'dir\n.secret\nREADME', 'use all flags -l -a and -1')
+  // })
+
+  // emulator.run('ls -la1 /home/test').then(function (output) {
+  //   t.equal(output, 'dir\n.secret\nREADME', 'use all flags -l -a and -1 combined')
+  // })
 })
 

--- a/test/commands/ls.js
+++ b/test/commands/ls.js
@@ -2,7 +2,7 @@ var test = require('tape')
 var bashEmulator = require('../../src')
 
 test('ls', function (t) {
-  t.plan(14)
+  t.plan(17)
 
   var emulator = bashEmulator({
     history: [],
@@ -144,12 +144,24 @@ test('ls', function (t) {
     t.equal(output, 'dir\n.secret\nREADME', 'list all & entry per line combined flags reverse order')
   })
 
-  // emulator.run('ls -l -a -1 /home/test').then(function (output) {
-  //   t.equal(output, 'dir\n.secret\nREADME', 'use all flags -l -a and -1')
-  // })
+  emulator.run('ls -l -a -1 /home/test').then(function (output) {
+    t.equal(output, 'dir\n.secret\nREADME', 'use all flags -l -a and -1 separate')
+  })
 
-  // emulator.run('ls -la1 /home/test').then(function (output) {
-  //   t.equal(output, 'dir\n.secret\nREADME', 'use all flags -l -a and -1 combined')
-  // })
+  emulator.run('ls -la1 /home/test').then(function (output) {
+    t.equal(output, 'dir\n.secret\nREADME', 'use all flags -l -a and -1 combined')
+  })
+
+  emulator.run('ls -la1 -l /home/test').then(function (output) {
+    var listing =
+      'total 3' +
+      '\n' +
+      'drwxrwxr-x test user  4096 May 14 07:10  dir/' +
+      '\n' +
+      '-rw-rw-r-- test user   456 May 14 07:10  .secret' +
+      '\n' +
+      '-rw-rw-r-- test user   123 Jan 01 03:35  README'
+    t.equal(output, listing, 'use all flags -l -a -1 combined overwrite with -1 (duplicate flag)')
+  })
 })
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,2 +1,3 @@
 require('./system')
 require('./commands')
+require('./utils')

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -1,0 +1,1 @@
+require('./parseCommandArgs')

--- a/test/utils/parseCommandArgs.js
+++ b/test/utils/parseCommandArgs.js
@@ -1,0 +1,12 @@
+const test = require('tape')
+const parseCommandArgs = require('../../src/utils/parseCommandArgs')
+
+test('parseCommandArgs', function (t) {
+  t.plan(1)
+
+  const expectedResult = [['l', 'a', '1', 'l', 'a', '1'], ['/home', '.']]
+
+  const result = parseCommandArgs(['-la', '-1', '/home', '.', '-la1'])
+
+  t.deepEqual(result, expectedResult, 'parse multiple flags with args')
+})


### PR DESCRIPTION
PR extends ls command so now is possible to:

1. `ls -la1` - use all flags combined in any order (in this case `1` overwrites `l`)
2. `ls -1 -l` - use separate flags (note in this case `-l` overwrites `-1`)

Additional tests were included and there is a new utility parser for command arguments. 
Code for `ls` command was rewritten to ES6.